### PR TITLE
layer.conf: Let the layer share downloads and sstate

### DIFF
--- a/meta-rcar-gen3-xen/conf/layer.conf
+++ b/meta-rcar-gen3-xen/conf/layer.conf
@@ -11,3 +11,6 @@ BBFILE_PRIORITY_rcar-gen3-xen = "6"
 
 PREFERRED_PROVIDER_iasl = "iasl-native"
 PREFERRED_PROVIDER_iasl-native = "iasl-native"
+
+SSTATE_DIR = "${TOPDIR}/../sstate-cache"
+DL_DIR = "${TOPDIR}/../downloads"


### PR DESCRIPTION
In order to speedup build of several machines from one yocto instance
let the layer keep downloads and sstate at common pathes.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>