### PR TITLE
temp: Add initrd.img blob and handle it as a guest resource

### DIFF
--- a/meta-rcar-gen3-xen/recipes-extended/guests/files/domu.cfg
+++ b/meta-rcar-gen3-xen/recipes-extended/guests/files/domu.cfg
@@ -21,6 +21,9 @@ dtdev=[ "/soc/gsx@fd000000", "/soc/gsx1@fd000000", "/soc/gsx2@fd000000", "/soc/g
 irqs=[ 151 ]
 iomem=[ "0xfd000,40" ]
 
+# Ramdisk (optional)
+ramdisk = "/boot/initrd/initrd.img"
+
 # Kernel command line options
 extra = "root=/dev/nfs nfsroot=192.168.1.100:/srv/domu ip=192.168.1.11 rw rootwait console=hvc0 cma=64M"
 

--- a/meta-rcar-gen3-xen/recipes-extended/guests/guests.bb
+++ b/meta-rcar-gen3-xen/recipes-extended/guests/guests.bb
@@ -16,6 +16,7 @@ SRC_URI = "\
   file://copy_test.sh \
   file://alive.sh \
   file://displ_be.cfg \
+  file://initrd.img \
 "
 
 S = "${WORKDIR}"
@@ -25,9 +26,12 @@ do_install() {
     install -m 0744 ${WORKDIR}/*.cfg ${D}${base_prefix}/xen
     install -d ${D}${base_prefix}/scripts
     install -m 0744 ${WORKDIR}/*.sh ${D}${base_prefix}/scripts
+    install -d ${D}${base_prefix}/boot/initrd
+    install -m 0777 ${WORKDIR}/*.img ${D}${base_prefix}/boot/initrd
 }
 
 FILES_${PN} = " \
     ${base_prefix}/xen/*.cfg \
     ${base_prefix}/scripts/*.sh \
+    ${base_prefix}/boot/initrd/*.img \
 "


### PR DESCRIPTION
These changes are needed for adding guest ramdisk and copying it
to the desired location.

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>