### PR TITLE
Missing space fixup

### DIFF
--- a/meta-rcar-gen3-xen/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/meta-rcar-gen3-xen/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -1,2 +1,2 @@
 # Start cores in EL2 mode
-ATFW_OPT_append = 'RCAR_BL33_EXECUTION_EL=BL33_EL2'
+ATFW_OPT_append = " RCAR_BL33_EXECUTION_EL=BL33_EL2"


### PR DESCRIPTION
In Yocto _append does not add a space before an appended string, so
add that space manually.

Reported-by: Iurii Artemenko <iurii_artemenko@epam.com>
Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>